### PR TITLE
Fix compilation error

### DIFF
--- a/dynamic.cabal
+++ b/dynamic.cabal
@@ -25,7 +25,8 @@ library
     containers,
     text,
     vector,
-    unordered-containers
+    unordered-containers,
+    http-conduit
   default-language:    Haskell2010
 
 source-repository head


### PR DESCRIPTION
```shell
λ stack repl --package dynamic
dynamic-0.0.2: configure
dynamic-0.0.2: build

Error: 
--  While building package dynamic-0.0.2 using:
      /Users/gupi/.stack/setup-exe-cache/x86_64-osx/Cabal-simple_mPHDZzAJ_2.4.0.1_ghc-8.6.3 --builddir=.stack-work/dist/x86_64-osx/Cabal-2.4.0.1 build --ghc-options " -ddump-hi -ddump-to-file -fdiagnostics-color=always"
    Process exited with code: ExitFailure 1
    Logs have been written to: /Users/gupi/.stack/global-project/.stack-work/logs/dynamic-0.0.2.log

    Configuring dynamic-0.0.2...
    Preprocessing library for dynamic-0.0.2..
    Building library for dynamic-0.0.2..
    [1 of 1] Compiling Dynamic          ( src/Dynamic.hs, .stack-work/dist/x86_64-osx/Cabal-2.4.0.1/build/Dynamic.o )
    
    /private/var/folders/p9/ln28v7zs7_53lz3ln4xyq2g00000gn/T/stack15974/dynamic-0.0.2/src/Dynamic.hs:63:1: error:
        Could not find module ‘Network.HTTP.Simple’
        Perhaps you meant
          Network.HTTP.Types (needs flag -package-key http-types-0.12.2)
        Use -v to see a list of the files searched for.
       |
    63 | import           Network.HTTP.Simple
```